### PR TITLE
Add support for unknown annotations

### DIFF
--- a/src/test/java/no/ssb/raml/RamltoJsonSchemaConverterTest.java
+++ b/src/test/java/no/ssb/raml/RamltoJsonSchemaConverterTest.java
@@ -90,6 +90,8 @@ public class RamltoJsonSchemaConverterTest {
                 Path plainJsonFilePath = DirectoryUtils.resolveRelativeFolderPath(temporaryJsonFileFolder.toString(), "ProvisionAgreement.json");
                 String jsonFileContent = DirectoryUtils.readFileContent(plainJsonFilePath);
 
+                assertFalse(jsonFileContent.contains("(Link.unsupported)"));
+
                 Object jsonDocumentObject = Configuration.defaultConfiguration().jsonProvider().parse(jsonFileContent);
 
                 if (jsonDocumentObject instanceof LinkedHashMap) {

--- a/src/test/java/no/ssb/raml/RamltoJsonSchemaConverterTest.java
+++ b/src/test/java/no/ssb/raml/RamltoJsonSchemaConverterTest.java
@@ -65,7 +65,12 @@ public class RamltoJsonSchemaConverterTest {
 
         RamltoJsonSchemaConverter.convertSchemas(new String[]{outputFolder.toString(), "src/test/resources/raml/schemas"});
 
-       // assertTrue(usage.isEmpty());
+        // Check that the result does not contain unsupported annotation.
+        String paJson = DirectoryUtils.readFileContent(DirectoryUtils.resolveRelativeFolderPath(outputFolder.toString(),
+                "ProvisionAgreement.json"));
+        assertFalse(paJson.contains("unsupported"));
+
+        // assertTrue(usage.isEmpty());
         LinkedHashMap<Object, Object> jsonSchemaDocument = new LinkedHashMap();
         LinkedHashMap<Object, Object> jsonDocument = new LinkedHashMap();
 
@@ -89,8 +94,6 @@ public class RamltoJsonSchemaConverterTest {
             if(DirectoryUtils.resolveRelativeFolderPath(temporaryJsonFileFolder.toString(), "Agent.json").toFile().exists()){
                 Path plainJsonFilePath = DirectoryUtils.resolveRelativeFolderPath(temporaryJsonFileFolder.toString(), "ProvisionAgreement.json");
                 String jsonFileContent = DirectoryUtils.readFileContent(plainJsonFilePath);
-
-                assertFalse(jsonFileContent.contains("(Link.unsupported)"));
 
                 Object jsonDocumentObject = Configuration.defaultConfiguration().jsonProvider().parse(jsonFileContent);
 

--- a/src/test/resources/raml/schemas/ProvisionAgreement.raml
+++ b/src/test/resources/raml/schemas/ProvisionAgreement.raml
@@ -61,6 +61,7 @@ types:
         type: string[]
         displayName: Exchange channels
         (Link.types): [ExchangeChannel]
+        (Link.unsupported):
 
       frequency:
         type: string

--- a/src/test/resources/raml/schemas/annotation/Link.raml
+++ b/src/test/resources/raml/schemas/annotation/Link.raml
@@ -4,3 +4,4 @@ annotationTypes:
   types:
     type: string[]
     description: Holds the type of objects a link points to
+  unsupported: nil


### PR DESCRIPTION
The resolveJsonLinks() only handled (Link.types). This is problematic because any experiment with new annotation is therefore impossible.
    
Any annotation thas is matching the regexp will now be dropped:
`\((?:([a-zA-Z0-9]+)\.)?([a-zA-Z0-9]+)\)`
    
I took the time to refactor the method as well to avoid using forEach and "holder" arrays or atomic references. It's a bit more verbose but easier to read IMO.